### PR TITLE
Fix mobile joystick bomb controls

### DIFF
--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -1021,14 +1021,14 @@ function startGame(levelMap: string[] | null = null) {
                     const up = Math.sin(angle);
                     const right = Math.cos(angle);
 
-                    if (up > 0.5) {
+                    if (up < -0.5) {
                         keys['ArrowUp'] = true;
                     } else {
                         keys['ArrowUp'] = false;
                     }
 
                     // Lógica para plantar la bomba
-                    if (up < -0.5) {
+                    if (up > 0.5) {
                         keys['ArrowDown'] = true;
                     } else {
                         keys['ArrowDown'] = false;


### PR DESCRIPTION
Correct inverted mobile joystick vertical controls so moving up flies and moving down plants a bomb.

---
<a href="https://cursor.com/background-agent?bcId=bc-5fe474a7-a569-417b-ad4a-41e6c7eaf0b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5fe474a7-a569-417b-ad4a-41e6c7eaf0b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

