### PR TITLE
Ajustar sprite de caminata del héroe

### DIFF
--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -516,7 +516,7 @@ function updatePlayer() {
             if (anim.reverse) {
                 player.currentFrame--;
                 if (player.currentFrame < 0) {
-                    player.currentFrame = anim.frames - 1;
+                    player.currentFrame = anim.frames - 2; // Start from second-to-last frame to avoid extra frame
                 }
             } else {
                 if (anim.loop !== false) {


### PR DESCRIPTION
Adjust reverse animation logic for hero walk sprite to prevent an extra frame from being displayed.

The previous logic caused an extra sprite frame to be displayed when the animation was reversed, as `anim.frames - 1` was incorrectly used as the starting point after looping from frame 0. Changing it to `anim.frames - 2` ensures the animation loops correctly without the extra frame.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e26346e-f86e-4a50-aa2c-3ad6575e64fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6e26346e-f86e-4a50-aa2c-3ad6575e64fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

