### PR TITLE
Flash background assets on bomb explosion

### DIFF
--- a/src/scripts/components/bomb.ts
+++ b/src/scripts/components/bomb.ts
@@ -127,6 +127,8 @@ export const updateBombs = (store: GameStore) => {
         const centerY = bomb.y + bomb.height / 2;
         createExplosion(store, bomb.x, bomb.y);
         emitParticles(store, centerX, centerY, 30, 'white');
+        // Trigger background flash effect
+        store.backgroundFlash = 15;
         const explosionRadius = 70;
         destroyWallsInRadius(store, centerX, centerY, explosionRadius);
         destroyEnemiesInRadius(store, centerX, centerY, explosionRadius);

--- a/src/scripts/components/effects.ts
+++ b/src/scripts/components/effects.ts
@@ -44,3 +44,9 @@ export const updateFloatingScores = (store: GameStore) => {
     }
 };
 
+export const updateBackgroundFlash = (store: GameStore) => {
+    if (store.backgroundFlash > 0) {
+        store.backgroundFlash -= 1;
+    }
+};
+

--- a/src/scripts/components/render.ts
+++ b/src/scripts/components/render.ts
@@ -5,7 +5,7 @@ import {
 } from '../core/constants';
 import type { GameStore, Wall, Enemy, FallingEntity } from '../core/types';
 import { checkCollision } from '../core/collision';
-import { updateParticles, updateFallingEntities, updateFloatingScores } from './effects';
+import { updateParticles, updateFallingEntities, updateFloatingScores, updateBackgroundFlash } from './effects';
 import { drawLight } from './light';
 
 const drawWall = (store: GameStore, wall: Wall) => {
@@ -240,7 +240,14 @@ const drawGameWorld = (store: GameStore) => {
     const canvas = store.dom.canvas;
     if (!ctx || !canvas) return;
 
-    ctx.fillStyle = 'black';
+    // Apply background flash if active
+    if (store.backgroundFlash > 0) {
+        const flashIntensity = store.backgroundFlash / 15;
+        const gray = Math.floor(flashIntensity * 200);
+        ctx.fillStyle = `rgb(${gray}, ${gray}, ${gray})`;
+    } else {
+        ctx.fillStyle = 'black';
+    }
     ctx.fillRect(0, 0, canvas.width, canvas.height);
     ctx.save();
     ctx.translate(0, -store.cameraY);
@@ -327,5 +334,6 @@ export const runEffects = (store: GameStore) => {
     updateParticles(store);
     updateFallingEntities(store);
     updateFloatingScores(store);
+    updateBackgroundFlash(store);
 };
 

--- a/src/scripts/core/state.ts
+++ b/src/scripts/core/state.ts
@@ -92,5 +92,6 @@ export const createInitialStore = (): GameStore => ({
             cancelSaveBtn: null,
         },
     },
+    backgroundFlash: 0,
 });
 

--- a/src/scripts/core/types.ts
+++ b/src/scripts/core/types.ts
@@ -212,5 +212,6 @@ export interface GameStore {
     joystickManager: JoystickManager | null;
     initialLevels: string[][];
     dom: DomReferences;
+    backgroundFlash: number;
 }
 

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -12,7 +12,7 @@ import { loadLevel, updateWalls, replenishEnergyOnGround, awardMinerRescue } fro
 import { updateEnemies, updateMiner } from './components/enemy';
 import { updateLasers } from './components/laser';
 import { updateBombs, updateExplosions } from './components/bomb';
-import { updateParticles, updateFallingEntities, updateFloatingScores } from './components/effects';
+import { updateParticles, updateFallingEntities, updateFloatingScores, updateBackgroundFlash } from './components/effects';
 import { renderGame, renderEditor } from './components/render';
 import { updateLights } from './components/light';
 
@@ -76,6 +76,7 @@ const updateGameState = () => {
     updateParticles(store);
     updateFallingEntities(store);
     updateFloatingScores(store);
+    updateBackgroundFlash(store);
     checkEnemyCollision(store);
     checkMinerRescue();
     updateCamera();


### PR DESCRIPTION
Add a background flash effect when bombs explode, visible even when lights are off.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a88532b-d03e-4d0d-9b1e-c55a07ffd5e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8a88532b-d03e-4d0d-9b1e-c55a07ffd5e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

