### PR TITLE
Fix typescript errors in enemy.ts

### DIFF
--- a/src/scripts/core/types.ts
+++ b/src/scripts/core/types.ts
@@ -59,7 +59,7 @@ export interface Enemy extends GameObject {
     initialX?: number;
     initialY?: number;
     maxLength?: number;
-    state?: 'extending' | 'retracting' | 'idle' | 'waiting_extended';
+    state?: 'extending' | 'retracting' | 'idle' | 'waiting_extended' | 'attacking';
     idleTimer?: number;
     waitTimer?: number;
     spriteTick: number;


### PR DESCRIPTION
Add 'attacking' to `Enemy.state` type to resolve TypeScript build errors.

The Netlify build was failing due to TypeScript errors (`TS2322` and `TS2678`) because the `'attacking'` state was being assigned and compared in `enemy.ts` but was not included in the `Enemy.state` type definition. This change explicitly adds `'attacking'` as a valid state.

---
<a href="https://cursor.com/background-agent?bcId=bc-2799bb7a-8104-4cc9-8964-0c40d9fd9032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2799bb7a-8104-4cc9-8964-0c40d9fd9032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

